### PR TITLE
bug fix: EhcacheShiroManager fail to locate external config

### DIFF
--- a/src/main/java/org/ehcache/integrations/shiro/EhcacheShiroManager.java
+++ b/src/main/java/org/ehcache/integrations/shiro/EhcacheShiroManager.java
@@ -158,7 +158,9 @@ public class EhcacheShiroManager implements CacheManager, Initializable, Destroy
   private URL getResource() throws MalformedURLException {
     String cacheManagerConfigFile = getCacheManagerConfigFile();
     if (cacheManagerConfigFile.startsWith(ResourceUtils.CLASSPATH_PREFIX)) {
-      return EhcacheShiroManager.class.getClass().getResource(stripPrefix(cacheManagerConfigFile));
+      URL url = EhcacheShiroManager.class.getClass().getResource(stripPrefix(cacheManagerConfigFile));
+      if(url==null) url = Thread.currentThread().getContextClassLoader ().getResource(stripPrefix(cacheManagerConfigFile));
+      return url;
     }
 
     final String url = ResourceUtils.hasResourcePrefix(cacheManagerConfigFile) ? stripPrefix(cacheManagerConfigFile)


### PR DESCRIPTION
bug fix: EhcacheShiroManager.class.getClass().getResource() returns null by using external ehcache config file